### PR TITLE
Disable 0px -> 0: always keep unit

### DIFF
--- a/lib/clean.js
+++ b/lib/clean.js
@@ -292,7 +292,7 @@ var minify = function(data, callback) {
   if (['ie7', 'ie8'].indexOf(options.compatibility) == -1)
     units.push('rem');
 
-  replace(new RegExp('(\\s|:|,)\\-?0(?:' + units.join('|') + ')', 'g'), '$1' + '0');
+  // replace(new RegExp('(\\s|:|,)\\-?0(?:' + units.join('|') + ')', 'g'), '$1' + '0');
   replace(new RegExp('(\\s|:|,)\\-?(\\d+)\\.(\\D)', 'g'), '$1$2$3');
   replace(new RegExp('rect\\(0(?:' + units.join('|') + ')', 'g'), 'rect(0');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clean-css",
-  "version": "2.2.23",
+  "version": "2.2.23-no-zero-units",
   "author": "Jakub Pawlowicz <jakub@goalsmashers.com> (http://twitter.com/GoalSmashers)",
   "description": "A well-tested CSS minifier",
   "license": "MIT",


### PR DESCRIPTION
- 0px will stay 0px
- 0% will stay 0%
- etc.

For Windows Store apps using Internet Explorer, an older standard of
Flexbox is used, where the last param to `flex` must have a unit, not be
unitless: any specific setting of `0px` will be optimised to `0` in
those cases. It's simpler to keep the unit in all cases than
specifically ignore for `flex`.
